### PR TITLE
Use local config for rabbitmq host address

### DIFF
--- a/app/util/common/config/platform.go
+++ b/app/util/common/config/platform.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/codelingo/lingo/service/config"
 	"github.com/juju/errors"
 )
@@ -58,6 +60,35 @@ func (p *platformConfig) GrpcAddress() (string, error) {
 	return addr + ":" + port, nil
 }
 
+func (p *platformConfig) MessageQueueAddr() (string, error) {
+	protocol, err := p.Get("messagequeue.address.protocol")
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	username, err := p.Get("messagequeue.address.username")
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	password, err := p.Get("messagequeue.address.password")
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	host, err := p.Get("messagequeue.address.host")
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	port, err := p.Get("messagequeue.address.port")
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	return fmt.Sprintf("%s://%s:%s@%s:%s/", protocol, username, password, host, port), nil
+}
+
 var PlatformTmpl = `
 all:
   addr: codelingo.io
@@ -67,6 +98,13 @@ all:
       name: "codelingo"
       addr: "http://codelingo.io"
       port: "3030"
+  messagequeue:
+    address:
+      protocol: "amqp"
+      username: "guest"
+      password: "guest"
+      host: "codelingo.io"
+      port: "5672"
 dev:
   addr: localhost
   gitserver:
@@ -74,6 +112,13 @@ dev:
       name: "codelingo_dev"
       addr: "http://localhost"
       port: "3000"
+  messagequeue:
+    address:
+      protocol: "amqp"
+      username: "guest"
+      password: "guest"
+      host: "localhost"
+      port: "5672"
 test:
   addr: localhost
   gitserver:
@@ -81,4 +126,11 @@ test:
       name: "codelingo_dev"
       addr: "http://localhost"
       port: "3000"
+  messagequeue:
+    address:
+      protocol: "amqp"
+      username: "guest"
+      password: "guest"
+      host: "localhost"
+      port: "5672"
 `[1:]

--- a/service/service.go
+++ b/service/service.go
@@ -29,8 +29,6 @@ import (
 	"github.com/codelingo/lingo/service/server"
 )
 
-const mqAddress = "amqp://guest:guest@localhost:5672/"
-
 type client struct {
 	context.Context
 	log.Logger
@@ -97,6 +95,15 @@ func (c client) Review(req *server.ReviewRequest) (<-chan *codelingo.Issue, erro
 	// Initialise review session and receive channel prefix
 	prefix, err := c.Session(&server.SessionRequest{})
 	req.Key = prefix
+
+	platConfig, err := config.Platform()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	mqAddress, err := platConfig.MessageQueueAddr()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	issueSubscriber, err := rabbitmq.NewSubscriber(mqAddress, prefix+"-issues", "")
 	if err != nil {


### PR DESCRIPTION
No changes required on server, this is good to go for client, but will need new `lingo setup` to work
