### PR TITLE
No edit on `lingo new`

### DIFF
--- a/.lingo
+++ b/.lingo
@@ -4,7 +4,5 @@ tenets:
 - name: find-funcs
   doc: Example tenet that finds all functions.
   comment: This is a function, but you probably already knew that.
-  match: |
+  match:
     <func
-# Add and configure tenets following these guidelines: http://codelingo/lingo/getting-started#the-lingo-file.
-

--- a/app/commands/new.go
+++ b/app/commands/new.go
@@ -36,7 +36,7 @@ func newLingoAction(ctx *cli.Context) {
 		util.OSErrf(err.Error())
 		return
 	}
-	fmt.Println("Successfully initialised. Lingo config file written in current directory")
+	fmt.Println("Success! A .lingo file has been written in the current directory. Edit it with your editor of choice to get started writing Tenets.")
 
 }
 
@@ -45,22 +45,8 @@ func newLingo(c *cli.Context) error {
 		return errors.Trace(err)
 	}
 
-	cfgPath, err := writeDotLingoToCurrentDir(c)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// TODO(waigani) don't hardcode vim. Use env var.
-	cmd, err := util.OpenFileCmd("vim", cfgPath, 1)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if err = cmd.Start(); err != nil {
-		return errors.Trace(err)
-
-	}
-	return cmd.Wait()
+	_, err := writeDotLingoToCurrentDir(c)
+	return errors.Trace(err)
 }
 
 func writeDotLingoToCurrentDir(c *cli.Context) (string, error) {
@@ -69,7 +55,7 @@ func writeDotLingoToCurrentDir(c *cli.Context) (string, error) {
 		return "", errors.Trace(err)
 	}
 	if _, err := os.Stat(cfgPath); err == nil {
-		return "", errors.Errorf("Already initialised. Using %q", cfgPath)
+		return "", errors.Errorf(".lingo file already exists: %q", cfgPath)
 	}
 
 	return cfgPath, writeDotLingo(cfgPath)


### PR DESCRIPTION
Don't open new .lingo file in vim for editing. Update success and error
messages to better instruct the user.