### PR TITLE
Update RabbitMQ User

### DIFF
--- a/app/util/common/config/platform.go
+++ b/app/util/common/config/platform.go
@@ -135,8 +135,8 @@ all:
   messagequeue:
     address:
       protocol: "amqp"
-      username: "guest"
-      password: "guest"
+      username: "codelingo"
+      password: "codelingo"
       host: "codelingo.io"
       port: "5672"
 dev:
@@ -151,8 +151,8 @@ dev:
   messagequeue:
     address:
       protocol: "amqp"
-      username: "guest"
-      password: "guest"
+      username: "codelingo"
+      password: "codelingo"
       host: "localhost"
       port: "5672"
 test:
@@ -167,8 +167,8 @@ test:
   messagequeue:
     address:
       protocol: "amqp"
-      username: "guest"
-      password: "guest"
+      username: "codelingo"
+      password: "codelingo"
       host: "localhost"
       port: "5672"
 `[1:]

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 9871d6de781d7d057822ca6334cbff44a4ba829c7d493fd301ff7efaf5ea2428
-updated: 2016-11-14T16:03:03.154037878+13:00
+updated: 2016-11-17T14:22:36.369276986+13:00
 imports:
 - name: github.com/blang/semver
   version: 60ec3488bfea7cca02b021d106d9911120d25fe9
@@ -15,6 +15,17 @@ imports:
   - sd
   - sd/lb
   - transport/grpc
+- name: github.com/coreos/go-systemd
+  version: b4a58d95188dd092ae20072bac14cece0e67c388
+  subpackages:
+  - activation
+  - dbus
+  - unit
+  - util
+- name: github.com/davecgh/go-spew
+  version: 6cf5744a041a0022271cefed95ba843f6d87fd51
+  subpackages:
+  - spew
 - name: github.com/docker/docker
   version: cc8b8ce0b3d2d6b3345687464d3a3b1c2c4971ef
   subpackages:
@@ -42,10 +53,19 @@ imports:
   version: dea9d3a26a087187530244679c1cfb3a42937794
 - name: github.com/fsouza/go-dockerclient
   version: 2ce05b8e04b7475b63ae21c1aeaf72b8a5b05eb5
+- name: github.com/gabriel-samfira/sys
+  version: 9ddc60d56b511544223adecea68da1e4f2153beb
+  subpackages:
+  - windows
+  - windows/registry
+  - windows/svc
+  - windows/svc/mgr
 - name: github.com/go-logfmt/logfmt
   version: d4327190ff838312623b09bfeb50d7c93c8d9c1d
 - name: github.com/go-stack/stack
   version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
+- name: github.com/godbus/dbus
+  version: c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f
 - name: github.com/gogits/go-gogs-client
   version: d8aff570fa22d4e38954c753ec8b21862239b31d
 - name: github.com/golang/protobuf
@@ -57,8 +77,29 @@ imports:
   version: ad28ea4487f05916463e2423a55166280e8254b5
 - name: github.com/juju/errors
   version: 1b5e39b83d1835fa480e0c2ddefb040ee82d58b3
+- name: github.com/juju/juju
+  version: 11682c54646fbe625120c0368b41b3349f04df77
+  subpackages:
+  - agent/tools
+  - cert
+  - controller
+  - feature
+  - juju/osenv
+  - juju/paths
+  - mongo
+  - network
+  - service
+  - service/common
+  - service/systemd
+  - service/upstart
+  - service/windows
+  - tools
 - name: github.com/juju/loggo
   version: 0e0537f18a29c2f0a814dad75b1ccc577852538a
+- name: github.com/juju/replicaset
+  version: fb7294cf57a1e2f08a57691f1246d129a87ab7e8
+- name: github.com/juju/schema
+  version: 29dd021fc4b6a9358065c5a06fbdf66a50a87a95
 - name: github.com/juju/testing
   version: 321edad6b2d1ccac4af9ee05c25b8ad734d40546
   subpackages:
@@ -66,7 +107,21 @@ imports:
 - name: github.com/juju/utils
   version: bdb77b07e7e3f77463d10d2b554cd1b7a78009a2
   subpackages:
+  - arch
   - clock
+  - exec
+  - featureflag
+  - filepath
+  - os
+  - packaging
+  - packaging/commands
+  - packaging/config
+  - packaging/manager
+  - proxy
+  - series
+  - set
+  - shell
+  - symlink
 - name: github.com/juju/version
   version: 4ae6172c00626779a5a462c3e3d22fc0e889431a
 - name: github.com/kr/logfmt
@@ -92,6 +147,8 @@ imports:
   version: a20910139607957cf3a4c0903421e637feebb621
 - name: github.com/pkg/browser
   version: 9302be274faad99162b9d48ec97b24306872ebb0
+- name: github.com/rogpeppe/fastuuid
+  version: 6724a57986aff9bff1a1770e9347036def7c89f6
 - name: github.com/Sirupsen/logrus
   version: 08a8a7c27e3d058a8989316a850daad1c10bf4ab
 - name: github.com/skratchdot/open-golang
@@ -106,10 +163,17 @@ imports:
   version: 2e25825abdbd7752ff08b270d313b93519a0a232
 - name: github.com/waigani/diffparser
   version: 42ae6ebdde8d5414cb002ac435c1d6be3f926c32
+- name: github.com/waigani/xxx
+  version: 996d259109d1481f6cb397c495801602216175e2
 - name: golang.org/x/crypto
   version: c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6
   subpackages:
+  - curve25519
+  - nacl/box
+  - nacl/secretbox
   - pbkdf2
+  - poly1305
+  - salsa20/salsa
   - ssh/terminal
 - name: golang.org/x/net
   version: 0d8126fc6144eb5257485c59148128691e8ff849
@@ -139,18 +203,29 @@ imports:
   - transport
 - name: gopkg.in/check.v1
   version: 4f90aeace3a26ad7021961c297b22c42160c7b25
+- name: gopkg.in/errgo.v1
+  version: 66cb46252b94c1f3d65646f54ee8043ab38d766c
+- name: gopkg.in/juju/names.v2
+  version: fa4c1959bef64b8f18569dc83a85b25d15204503
+- name: gopkg.in/macaroon-bakery.v1
+  version: 469b44e6f1f9479e115c8ae879ef80695be624d5
+  subpackages:
+  - bakery
+  - bakery/checkers
+- name: gopkg.in/macaroon.v1
+  version: d8fd13e6951f2ce46f0964a58149cf2f103cac9a
 - name: gopkg.in/mgo.v2
   version: 01ee097136da162d1dd3c9b44fbdf3abf4fd6552
   subpackages:
   - bson
   - internal/sasl
   - internal/scram
+- name: gopkg.in/tomb.v1
+  version: dd632973f1e7218eb1089048e0798ec9ae7dceb8
 - name: gopkg.in/yaml.v1
   version: 9f9df34309c04878acc86042b16630b0f696e1de
 - name: gopkg.in/yaml.v2
   version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
 - name: sourcegraph.com/sourcegraph/appdash
   version: ca429ff5af815db4185bbc0ab3984a483eb37ee6
-testImports:
-- name: github.com/waigani/xxx
-  version: 996d259109d1481f6cb397c495801602216175e2
+testImports: []


### PR DESCRIPTION
The default RabbitMQ guest user cannot access the queue outside of localhost.
The platform now creates a "codelingo" user to access the queue. Update the
platform config template to create a codelingo user instead of guest. This
will enable the client to work with the remote production server as well as
the local dev one.