### PR TITLE
Highlight .lingo files rather than *.lingo files.

### DIFF
--- a/scripts/IDE/sublime/completions/tenets.sublime-completions
+++ b/scripts/IDE/sublime/completions/tenets.sublime-completions
@@ -1,12 +1,12 @@
 {
-	"scope": "tenets.lingo -CLQL.lingo",
+	"scope": "tenets.lingo tenet.lingo -CLQL.lingo",
 
 	"completions":
 	[
-		{ "trigger": "name", "contents": "name: ${1:Name}"},
-		{ "trigger": "doc", "contents": "doc: ${1:Description}"},
-		{ "trigger": "comment", "contents": "comment: ${1:Review comment}"},
-		{ "trigger": "match", "contents": "match: \n\t" }
+		{ "trigger": "name\tName", "contents": "name: ${1:Name}"},
+		{ "trigger": "doc\tDescription", "contents": "doc: ${1:Description}"},
+		{ "trigger": "comment\tReview Comment", "contents": "comment: ${1:Review comment}"},
+		{ "trigger": "match\tQuery", "contents": "match: " }
 
 	],
 }

--- a/scripts/IDE/sublime/syntax/lingo.sublime-syntax
+++ b/scripts/IDE/sublime/syntax/lingo.sublime-syntax
@@ -59,6 +59,6 @@ contexts:
     - match: "[a-zA-Z0-9\"]+"
       scope: string.unquoted.single.lingo
 file_extensions:
-  - lingo
+  - .lingo
 name: lingo
 scope: source.lingo


### PR DESCRIPTION
Make tenet scope autocomplete easier to use.