### PR TITLE
Remove `glide update` from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,6 @@ install:
 
 	# then get the latest commit
 	git pull
-
-	# update dep shas
-	glide update
 	
 	# install deps
 	glide install


### PR DESCRIPTION
`glide update` errors and fails to complete, thus `make install` fails:

```
[ERROR]	Failed to retrieve a list of dependencies: Error resolving imports
make: *** [install] Error 1
```

Remove `glide update` lines from Makefile to avoid introducing first run issues with dependencies.