### PR TITLE
Remove "repo owner($)" prompt from `lingo init`

### DIFF
--- a/app/commands/init.go
+++ b/app/commands/init.go
@@ -55,12 +55,6 @@ func initRepo(ctx *cli.Context) (string, string, error) {
 	if err != nil {
 		return "", "", errors.Trace(err)
 	}
-	var repoOwnerCustom string
-	fmt.Printf("repo owner(%s): ", repoOwner)
-	fmt.Scanln(&repoOwnerCustom)
-	if repoOwnerCustom != "" {
-		repoOwner = repoOwnerCustom
-	}
 
 	// get the repo name, default to working directory name
 	dir, err := os.Getwd()


### PR DESCRIPTION
Remove `repoOwnerCustom` prompt and scan lines from `app/commands/init.go`