### PR TITLE
Remove repo name prompt from lingo init correctly

### DIFF
--- a/app/commands/init_internal_test.go
+++ b/app/commands/init_internal_test.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/codelingo/lingo/vcs/backing"
+	"github.com/codelingo/lingo/vcs/mock"
+)
+
+func TestRepoNaming(t *testing.T) {
+	cases := []struct {
+		r                         backing.Repo
+		dirName, expectedRepoName string
+		expectedErr               error
+	}{
+		{
+			r:                &mock.Repo{},
+			dirName:          "freshPkg",
+			expectedRepoName: "freshPkg",
+			expectedErr:      nil,
+		},
+		{
+			r:                &mock.Repo{},
+			dirName:          "existingPkg",
+			expectedRepoName: "existingPkg-1",
+			expectedErr:      nil,
+		},
+		{
+			r:                &mock.Repo{},
+			dirName:          "existingPkg-1105",
+			expectedRepoName: "existingPkg-1106",
+			expectedErr:      nil,
+		},
+		{
+			r:                &mock.Repo{},
+			dirName:          "existing-Pkg-0",
+			expectedRepoName: "existing-Pkg-0-1",
+			expectedErr:      nil,
+		},
+	}
+
+	for _, c := range cases {
+		gotName, gotErr := createRepo(c.r, c.dirName)
+		if gotName != c.expectedRepoName {
+			t.Error(`want: `, c.expectedRepoName, `
+		got: `, gotName)
+		}
+		if reflect.DeepEqual(gotErr, c.expectedErr) == false {
+			t.Error(`want: `, c.expectedErr.Error(), `
+		got: `, gotErr.Error())
+		}
+	}
+
+}

--- a/vcs/backing/backing.go
+++ b/vcs/backing/backing.go
@@ -11,6 +11,7 @@ type Repo interface {
 	CreateRemote(name string) error
 	Exists(name string) (bool, error)
 	OwnerAndNameFromRemote() (string, string, error)
+	AssertNotTracked() error
 }
 
 const (

--- a/vcs/git/git.go
+++ b/vcs/git/git.go
@@ -132,6 +132,21 @@ func (r *Repo) OwnerAndNameFromRemote() (string, string, error) {
 	//
 }
 
+func (r *Repo) AssertNotTracked() error {
+
+	out, err := gitCMD("remote", "show", "-n")
+	if err != nil {
+		return errors.Annotate(err, out)
+	}
+	parts := strings.Split(out, "\n")
+	for _, p := range parts {
+		if p == "codelingo" {
+			return errors.New("codelingo git remote already exists")
+		}
+	}
+	return nil
+}
+
 func (r *Repo) CreateRemote(name string) error {
 
 	gogsClient, err := gogsClientForCurrentUser()
@@ -173,6 +188,9 @@ func (r *Repo) CurrentCommitId() (string, error) {
 
 	return out, nil
 }
+
+// TODO(benjamin-rood) Check git version to ensure expected cmd and behaviour
+// by any git command-line actions
 
 func gitCMD(args ...string) (out string, err error) {
 	cmd := exec.Command("git", args...)

--- a/vcs/mock/repo.go
+++ b/vcs/mock/repo.go
@@ -1,0 +1,53 @@
+package mock
+
+import "errors"
+
+// Repo mocking for unit testing.
+// Intended to mock behaviour of the git.Repo implementation.
+type Repo struct {
+}
+
+// Minimal methods which implement backing.Repo interface.
+// All methods reurn the default "zero" values except where fleshed out.
+
+func (mockrepo *Repo) Sync() error {
+	return nil
+}
+
+func (mockrepo *Repo) CurrentCommitId() (string, error) {
+	return "", nil
+}
+
+func (mockrepo *Repo) Patches() ([]string, error) {
+	return nil, nil
+}
+
+func (mockrepo *Repo) SetRemote(owner, name string) (string, string, error) {
+	return "", "", nil
+}
+func (mockrepo *Repo) CreateRemote(name string) error {
+	switch name {
+	case "existingPkg":
+		return errors.New("already exists")
+	case "existingPkg-1105":
+		return errors.New("already exists")
+	case "existing-Pkg":
+		return errors.New("already exists")
+	case "existing-Pkg-0":
+		return errors.New("already exists")
+	}
+
+	return nil
+}
+
+func (mockrepo *Repo) Exists(name string) (bool, error) {
+	return false, nil
+}
+
+func (mockrepo *Repo) OwnerAndNameFromRemote() (string, string, error) {
+	return "", "", nil
+}
+
+func (mockrepo *Repo) AssertNotTracked() error {
+	return nil
+}


### PR DESCRIPTION
1.  Grab the root dir name _(already present in code)_
2. Check if <username>/<root-dir-name> exists in GOGS.
3. If so, does append the name with an incremented int.

  * Add `createRepo` function which recursively increments possible names and checks against repo list associated with user, returning a distinct name string to be used by `SetRemote`.

  * Factor `repo.CreateRemote` out of `initRepo`, and into `createRepo`.

  * Add `alreadyInitialised()` function which checks if "codelingo" present in list of git remote names. Necessary to avoid work and avoid adding junk repo names in GOGS associated with the user/repoOwner.

  * TODO: In step 2, need to check if this isn't actually the same repo - in which case it should be a no-op.

post-review:

  * Add `AssertNotTracked()` method to `vcs/backing.Repo` interface.

  * Implement `AssertNotTracked()` method on `vcs/git.Repo` type, using the code from previous `alreadyInitialised()` function.

  * Add a TODO to check the git version inside `gitCMD` function in `vcs/git.go`

  * Create package `vcs/mock` to use for unit tests.

  * Create `vcs/mock/repo.go` for `mock.Repo` to implement `vcs/backing.Repo` interface with minimum mock response data required for unit testing.

  * Create `init_internal_test.go` in `app/commands`, using `mock.Repo` to test behaviour of `createRepo` function.