### PR TITLE
Update setup cmd w.r.t. configs/version.yaml

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/codelingo/lingo/app/commands"
+	"github.com/codelingo/lingo/app/util/common"
 )
 
 // TODO(waigani) have a global state that tenets can share. An issue may be
@@ -19,7 +20,7 @@ func New() *cli.App {
 	app.Usage = "Code Quality That Scales."
 	app.Before = commands.Before
 	app.Commands = commands.All()
-	app.Version = commands.ClientVersion
+	app.Version = common.ClientVersion
 	// TODO(waigani) once messaging is implemented, add -q flag to suppress them here.
 	// app.Flags = common.GlobalOptions
 	// app.CommandNotFound = commands.TenetCMD

--- a/app/commands/commands.go
+++ b/app/commands/commands.go
@@ -8,8 +8,6 @@ import (
 	"github.com/codegangsta/cli"
 )
 
-const ClientVersion = "0.1.1"
-
 type lingoCMD struct {
 	isSubCMD bool
 	cmd      *cli.Command

--- a/app/commands/list_facts.go
+++ b/app/commands/list_facts.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
+
 	"github.com/codegangsta/cli"
 	"github.com/codelingo/lingo/app/util"
 	"github.com/codelingo/lingo/service"
@@ -24,7 +25,7 @@ func init() {
 				Usage: "A filepath to output lexicon data to. If the flag is not set, outputs to cli.",
 			},
 		},
-	}, false)
+	}, false, versionRq)
 }
 
 func listFactsAction(ctx *cli.Context) {

--- a/app/commands/list_lexicons.go
+++ b/app/commands/list_lexicons.go
@@ -4,14 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/codegangsta/cli"
-	"github.com/codelingo/lingo/app/util"
-	"github.com/codelingo/lingo/service"
 	"io/ioutil"
 	"strings"
 
-	"github.com/juju/errors"
+	"github.com/codegangsta/cli"
+	"github.com/codelingo/lingo/app/util"
+	"github.com/codelingo/lingo/service"
+
 	"path/filepath"
+
+	"github.com/juju/errors"
 
 	"os"
 )
@@ -31,7 +33,7 @@ func init() {
 				Usage: "A filepath to output lexicon data to. If the flag is not set, outputs to cli.",
 			},
 		},
-	}, false)
+	}, false, versionRq)
 }
 
 func listLexiconsAction(ctx *cli.Context) {

--- a/app/commands/new.go
+++ b/app/commands/new.go
@@ -21,7 +21,7 @@ func init() {
 		Name:   "new",
 		Usage:  "Create a .lingo file in the current directory",
 		Action: newLingoAction,
-	}, false, vcsRq)
+	}, false, vcsRq, versionRq)
 }
 
 var intro = `

--- a/app/commands/pullrequest.go
+++ b/app/commands/pullrequest.go
@@ -40,7 +40,7 @@ var pullRequestCmd = &cli.Command{
 func init() {
 	register(pullRequestCmd,
 		true,
-		homeRq, authRq, configRq,
+		homeRq, authRq, configRq, versionRq,
 	)
 }
 

--- a/app/commands/review.go
+++ b/app/commands/review.go
@@ -46,7 +46,7 @@ func init() {
 		Action: reviewAction,
 	},
 		false,
-		vcsRq, dotLingoRq, homeRq, authRq, configRq,
+		vcsRq, dotLingoRq, homeRq, authRq, configRq, versionRq,
 	)
 }
 

--- a/app/commands/update.go
+++ b/app/commands/update.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/blang/semver"
+	"github.com/codelingo/lingo/app/util/common"
 
 	"github.com/codegangsta/cli"
 )
@@ -36,7 +37,7 @@ func updateAction(ctx *cli.Context) {
 	fmt.Println("DISABLED: the update command will be enabled once the codelingo/lingo repository is public")
 
 	// first check if an update is avaliable
-	v, err := semver.Make(ClientVersion)
+	v, err := semver.Make(common.ClientVersion)
 	if err != nil {
 		fmt.Println(err.Error())
 		return

--- a/app/util/common/common.go
+++ b/app/util/common/common.go
@@ -1,3 +1,5 @@
 package common
 
+const ClientVersion = "0.1.1"
+
 // go install doesn't like empty dirs

--- a/app/util/common/config/config.go
+++ b/app/util/common/config/config.go
@@ -13,6 +13,7 @@ const (
 	DefaultsCfgFile = "defaults.yaml"
 	ServicesCfgFile = "services.yaml"
 	PlatformCfgFile = "platform.yaml"
+	VersionCfgFile  = "version.yaml"
 )
 
 // Load assumes cfgFilename is relative to $LINGO_HOME. It loads the config

--- a/app/util/common/config/version.go
+++ b/app/util/common/config/version.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"github.com/codelingo/lingo/app/util/common"
+	"github.com/codelingo/lingo/service/config"
+	"github.com/juju/errors"
+)
+
+type versionConfig struct {
+	*config.Config
+}
+
+func Version() (*versionConfig, error) {
+	cfgPath, err := fullCfgPath(VersionCfgFile)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	cfg, err := config.New(cfgPath)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &versionConfig{
+		Config: cfg,
+	}, nil
+}
+
+func (v *versionConfig) ClientVersion() (string, error) {
+	return v.Get("client.version")
+}
+
+func (v *versionConfig) SetClientVersion(cv string) error {
+	// TODO: Use `hashicorp/go-version` package for comparing and setting semvers
+	// https://github.com/hashicorp/go-version
+	return v.Set("all.client.version", cv)
+}
+
+var VersionTmpl = `
+all:
+  client:
+    version: `[1:] + common.ClientVersion + `
+`

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -26,6 +26,8 @@ func ENV() string {
 	return "all"
 }
 
+// TODO: switch Config to an interface type and refactor
+
 type Config struct {
 	data     map[string]interface{}
 	filename string


### PR DESCRIPTION
 Req'd:

> When a new version of the lingo client is released, upgrade steps may need to be made. In particular, updating ~/.codelingo
> 
> Update the setup command to write the client version into a config file ~/.codelingo/configs/version.yaml
> 
> (Note: If a version can't be found it's the same logic as if the version doesn't match)
> 
> Add a flag --keep-creds to  lingo setup. When run with the flag, the existing username and token are kept, but all other configs are reset.
> 
> if --keep-creds can't find username or token, user should be prompted to enter them (as per normal setup)
> 
> Add a pre-command hook which prompts the user to run `lingo setup --keep-creds` if the client and config versions are out of sync. Use a package to compare semvers (look on github for a popular one - check licensing).
> 
> The pre-command hooks are written in app/commands/verify.go. They are added to a command when you register() the command (look at review.go as an example).
> 
> In the future we'll add proper upgrade steps, but this gets us out of trouble for now.


  * Move `const ClientVersion = ...` out of `app/commands` package and into `app` to avoid circular imports.

  * Add filename string const for _version_ to `app/util/common/config/config.go`

  * Create `app/util/common/config/version.go`, modeled from `app/util/common/config/platform.go`.

  * Add check for `~/.codelingo/configs/version.yaml` to `verifyConfig()` in `apps/commands/commands.go`.

  * Remove redundant code at top of `verifyConfig()`.

  * Add TODO: switch Config to an interface type and refactor to `service/config/config.go`

Post-Review 1:

  * Add `verifyClientVersion()` to `app/commands/verify.go`, so that the setup cmd checks for existence of `version.yaml` and checks for matching client version between running app version and what has been previously stored in `version.yaml`.
    
  * Add `versionRq` pre-command hook to all cmds other than setup.
    
  * Update `setupLingo` function to write the client version into the config file whenever the setup cmd is run.
    
  * Add TODO to use `hashicorp/go-version` package to ensure correct semver setting and compairsons.

Post-Review 2:

  * Add correct client version mismatch error message to `verifyClientVersion` function.
    
  * Add setup cmd boolean flag `--keep-creds` in `app/commands/setup.go`
    
  * Add logic for `--keep-creds` flag, and tidy + rearrange code blocks in `setupLingo` function in `setup.go` to be able to *elide* code for user prompts and inputs if existing username and password/token present in `~/.codelingo/configs/auth.config`, and for more logical ordering of variable inits.
    
  * Rename `authCfg` → `authConfig` for consistency with other variable names in `setupLingo`