### PR TITLE
WIP handle missing configs/auth.yaml

### DIFF
--- a/app/commands/verify.go
+++ b/app/commands/verify.go
@@ -181,7 +181,15 @@ func verifyConfig() error {
 	if _, err := os.Stat(configsHome); os.IsNotExist(err) {
 		err := os.MkdirAll(configsHome, 0775)
 		if err != nil {
-			errors.Annotatef(err, "WARNING: could not create configs directory")
+			return errors.Annotate(err, "verifyConfig: Could not create configs directory")
+		}
+	}
+
+	authCfg := filepath.Join(configsHome, utilConfig.AuthCfgFile)
+	if _, err := os.Stat(authCfg); os.IsNotExist(err) {
+		err := ioutil.WriteFile(authCfg, []byte(utilConfig.AuthTmpl), 0644)
+		if err != nil {
+			return errors.Annotate(err, "verifyConfig: Could not create auth config")
 		}
 	}
 
@@ -189,7 +197,7 @@ func verifyConfig() error {
 	if _, err := os.Stat(platformCfg); os.IsNotExist(err) {
 		err := ioutil.WriteFile(platformCfg, []byte(utilConfig.PlatformTmpl), 0644)
 		if err != nil {
-			fmt.Printf("WARNING: could not create platform config: %v \n", err)
+			return errors.Annotate(err, "verifyConfig: Could not create platform config")
 		}
 	}
 
@@ -197,7 +205,7 @@ func verifyConfig() error {
 	if _, err := os.Stat(versionCfg); os.IsNotExist(err) {
 		err := ioutil.WriteFile(versionCfg, []byte(utilConfig.VersionTmpl), 0644)
 		if err != nil {
-			fmt.Printf("WARNING: could not create version config: %v \n", err)
+			return errors.Annotate(err, "verifyConfig: Could not create version config")
 		}
 	}
 

--- a/app/util/common/config/auth.go
+++ b/app/util/common/config/auth.go
@@ -1,0 +1,15 @@
+package config
+
+var AuthTmpl = `
+all:
+  gitserver:
+    credentials_filename: git-credentials
+    user:
+      password: ""
+      username: ""
+dev:
+  gitserver:
+    credentials_filename: git-credentials-dev
+test:
+  gitserver:
+    credentials_filename: git-credentials-test`[1:]

--- a/app/util/common/config/config.go
+++ b/app/util/common/config/config.go
@@ -14,6 +14,7 @@ const (
 	ServicesCfgFile = "services.yaml"
 	PlatformCfgFile = "platform.yaml"
 	VersionCfgFile  = "version.yaml"
+	AuthCfgFile     = "auth.yaml"
 )
 
 // Load assumes cfgFilename is relative to $LINGO_HOME. It loads the config


### PR DESCRIPTION
**Bug found:** When running `lingo setup`, if auth.yaml doesn’t exist it errors rather than creates it from a template (as per platform.yaml and version.yaml config files), discovered when starting from a fresh install, replicated on another current install. The same is true if ~/.codelingo/configs directory is deleted.

Given that this was not happening before, this means it's probably a regression from the recent PRs to lingo.

In the process of fixing this bug, looking at the code and my "solution" both strongly suggest to implement to AuthConfig TODO, moving `AuthConfig` logic from `app/util` to `util/common/config`. As a result, this is a work in process PR.

Commit msg:

  * Start process of moving `AuthConfig` logic from `app/util` to `util/common/config` per TODO, matching platform/version config example.

  * Add `AuthCfgFile` constant filename string to `app/util/common/config/config.go`.

  * Add  `util/common/config/auth.go`, and `AuthTmpl` string in same manner as `PlatformTmpl` and `VersionTmpl`.

  * Add code to `app/commands/verify.go` in `verifyConfig()` func which creates a `~/.codelingo/configs/auth.yaml` based on `AuthTmpl`, in the same manner as the platform and version configs.