### PR TITLE
Send cancel signal on exit

### DIFF
--- a/.lingo
+++ b/.lingo
@@ -5,4 +5,3 @@ tenets:
   doc: Example tenet that finds all functions.
   comment: This is a function, but you probably already knew that.
   match:
-    <func


### PR DESCRIPTION
Send a cancel signal to the platform when a review is cancelled.