### PR TITLE
WIP: Ingestion Progress Bar in `lingo review` console

### DIFF
--- a/app/commands/review/review.go
+++ b/app/commands/review/review.go
@@ -1,10 +1,11 @@
 package review
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/cheggaaa/pb"
 	"github.com/codelingo/lingo/service/grpc/codelingo"
 	"github.com/codelingo/lingo/service/server"
 	"github.com/codelingo/lingo/vcs"
@@ -85,7 +86,7 @@ func Review(opts Options) ([]*codelingo.Issue, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	issuesc, messagesc, err := svc.Review(reviewReq)
+	issuesc, _, ingestPingc, err := svc.Review(reviewReq)
 	if err != nil {
 		if noCommitErr(err) {
 			return nil, errors.New(noCommitErrMsg)
@@ -94,19 +95,23 @@ func Review(opts Options) ([]*codelingo.Issue, error) {
 		return nil, errors.Annotate(err, "\nbad request")
 	}
 
-	// TODO(waigani) these should both be chans - as per firt MVP.
-	var confirmedIssues []*codelingo.Issue
-	go func() {
-		for message := range messagesc {
-			//  Currently, the message chan just prints while we're waiting
-			//  for issues. So we don't worry about closing it or timeouts
-			//  etc.
-			if message != "" {
-				fmt.Println(string(message))
-			}
+	// This first ping holds the total number of files to be ingested
+	// on the platform, which we use to initialise the progress bar.
+	ping := <-ingestPingc
+	fileTotal, err := strconv.Atoi(ping)
+	if err != nil {
+		panic(err) // can't directly return from inside this goroutine.
+	}
+	ingestProgress := pb.StartNew(fileTotal)
+	for _ = range ingestPingc {
+		if ingestProgress.Increment() == fileTotal {
+			ingestProgress.Finish()
+			break
 		}
-	}()
+	}
 
+	// TODO(waigani) these should both be chans - as per first MVP.
+	var confirmedIssues []*codelingo.Issue
 	output := opts.SaveToFile == ""
 	cfm, err := NewConfirmer(output, opts.KeepAll, nil)
 	if err != nil {

--- a/service/server/service.go
+++ b/service/server/service.go
@@ -12,12 +12,14 @@ type Message string
 
 type Messagec chan Message
 
+type Ingestc chan string
+
 type Issuec chan *codelingo.Issue
 
 type CodeLingoService interface {
 	Session(*SessionRequest) (string, error)
 	Query(src string) (string, error)
-	Review(*ReviewRequest) (Issuec, Messagec, error)
+	Review(*ReviewRequest) (Issuec, Messagec, Ingestc, error)
 	ListLexicons() ([]string, error)
 	ListFacts(lexicon string) (map[string][]string, error)
 }
@@ -27,7 +29,16 @@ func (mc Messagec) Send(msgFmt string, vars ...interface{}) error {
 	case mc <- Message(fmt.Sprintf(msgFmt, vars...)):
 	case <-time.After(time.Second * 5):
 		// TODO(waigani) error type
-		return errors.New("timeout")
+		return errors.New("timeout Messagec.Send: " + fmt.Sprintf(msgFmt, vars...))
+	}
+	return nil
+}
+
+func (ingc Ingestc) Send(s string) error {
+	select {
+	case ingc <- s:
+	case <-time.After(time.Second * 5):
+		return errors.New("timeout Ingestc.Send")
 	}
 	return nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -105,16 +106,16 @@ func (c client) ListLexicons() ([]string, error) {
 	return r.Lexicons, nil
 }
 
-func (c client) Review(req *server.ReviewRequest) (server.Issuec, server.Messagec, error) {
+func (c client) Review(req *server.ReviewRequest) (server.Issuec, server.Messagec, server.Ingestc, error) {
 	// set defaults
 	if req.Host == "" {
-		return nil, nil, errors.New("repository host is not set")
+		return nil, nil, nil, errors.New("repository host is not set")
 	}
 	if req.Owner == "" {
-		return nil, nil, errors.New("repository owner is not set")
+		return nil, nil, nil, errors.New("repository owner is not set")
 	}
 	if req.Repo == "" {
-		return nil, nil, errors.New("repository name is not set")
+		return nil, nil, nil, errors.New("repository name is not set")
 	}
 
 	// Initialise review session and receive channel prefix
@@ -123,27 +124,36 @@ func (c client) Review(req *server.ReviewRequest) (server.Issuec, server.Message
 
 	platConfig, err := config.Platform()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, nil, errors.Trace(err)
 	}
 	mqAddress, err := platConfig.MessageQueueAddr()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, nil, errors.Trace(err)
 	}
 
+	// TODO: Make prefix+"-issues" and equivs constants as they are shared
+	// between codelingo/platform and codelingo/lingo
 	issueSubscriber, err := rabbitmq.NewSubscriber(mqAddress, prefix+"-issues", "")
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, nil, errors.Trace(err)
 	}
 
 	messageSubscriber, err := rabbitmq.NewSubscriber(mqAddress, prefix+"-messages", "")
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, nil, errors.Trace(err)
+	}
+
+	ingestSubscriber, err := rabbitmq.NewSubscriber(mqAddress, prefix+"-ingest-progress", "")
+	if err != nil {
+		return nil, nil, nil, errors.Trace(err)
 	}
 
 	issueSubc := issueSubscriber.Start()
 	messageSubc := messageSubscriber.Start()
+	ingestSubc := ingestSubscriber.Start()
 	issuec := make(server.Issuec)
 	messagec := make(server.Messagec)
+	ingestc := make(server.Ingestc)
 
 	// helper func to send errors to the message chan
 	sendErrIfErr := func(err error) bool {
@@ -157,26 +167,62 @@ func (c client) Review(req *server.ReviewRequest) (server.Issuec, server.Message
 		return false
 	}
 
-	// read from subscriber chans onto issue and message chans, transforming
-	// pubsub.Message into codelingo.Issue or server.Message
+	// read from subscriber chans onto message, issue, and ingest chans,
+	// transforming pubsub.Message into codelingo.Issue or server.Message
+	// (or a straight string in the case of the working version of ingest chan)
+
+	// TODO(waigani) !ok is never used and isEnd(byt) is a workarond.
+	// A proper pubsub should close the chan upstream.
 	go func() {
 		defer close(messagec)
-		defer close(issuec)
-		defer issueSubscriber.Stop()
 		defer messageSubscriber.Stop()
 	l:
 		for {
 			select {
+			case msg, ok := <-messageSubc:
+				byt, err := ioutil.ReadAll(msg)
+				if err != nil {
+					sendErrIfErr(err)
+				}
+				if !ok ||
+					isEnd(byt) {
+					// no more messages.
+					break l
+				}
+				fmt.Println(string(byt))
+			case <-time.After(time.Second * 5):
+				break
+			}
+		}
+	}()
+
+	go func() {
+		defer close(ingestc)
+		defer close(issuec)
+		defer issueSubscriber.Stop()
+		defer ingestSubscriber.Stop()
+		for {
+			ingestPing, ok := <-ingestSubc
+			byt, err := ioutil.ReadAll(ingestPing)
+			if sendErrIfErr(err) ||
+				sendErrIfErr(ingestc.Send(string(byt))) ||
+				!ok ||
+				isEnd(byt) {
+				// no more ingestion updates.
+				break
+			}
+		}
+	l:
+		for {
+			select {
 			case issueMsg, ok := <-issueSubc:
-				// TODO(waigani) !ok is never used and isEnd is a workarond. A
-				// proper pubsub should close the chan upstream.
 				byt, err := ioutil.ReadAll(issueMsg)
 				if sendErrIfErr(err) {
 					break l
 				}
 				if !ok || isEnd(byt) {
 					// no more issues.
-					break l
+					break
 				}
 
 				issue := &codelingo.Issue{}
@@ -186,19 +232,7 @@ func (c client) Review(req *server.ReviewRequest) (server.Issuec, server.Message
 					break l
 				}
 
-			case msg, ok := <-messageSubc:
-				byt, err := ioutil.ReadAll(msg)
-				if sendErrIfErr(err) ||
-					!ok ||
-					isEnd(byt) {
-					// no more messages.
-					break l
-				}
-
-				// TODO: Process messages
-				sendErrIfErr(messagec.Send(string(byt) + "\n"))
-				sendErrIfErr(msg.Done())
-				// TODO(waigani) DEMOWARE setting to 600
+			// TODO(waigani) DEMOWARE setting to 600
 			case <-time.After(time.Second * 600):
 				sendErrIfErr(errors.New("timed out waiting for issues x"))
 				break l
@@ -208,10 +242,10 @@ func (c client) Review(req *server.ReviewRequest) (server.Issuec, server.Message
 
 	_, err = c.endpoints["review"](c.Context, req)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return issuec, messagec, nil
+	return issuec, messagec, ingestc, nil
 }
 
 // TODO(waigani) construct logger separately and pass into New.


### PR DESCRIPTION
**note: should not be merged into master!**

Current sample console output result:

    codelingo@codelingo-dev:~/testing/lingo/tmp$ lingo review
    ingesting nodes ...
    2 / 2 [================================================================================] 100.00% 0s
    ingest complete!
    sending the ingestPing errored or ingestSubc closed.
    main.go:7:12

        This is a function, but you probably already knew that.
        

        ...
        )
        
    > func main() {
        fmt.Println("Hello world")
        }
        
        ...

    [o]pen [d]iscard [K]eep: K
    test.php:4

        This is a function, but you probably already knew that.
        

        ...
        
    > function writeMsg() {
    >     echo "Hello world!";
    > }
        
        writeMsg(); // call the function
        
        ...

    [o]pen [d]iscard [K]eep: K


    ^C  

After manually processing the issues, `lingo review` does not finish - it just hangs there indefinitely or until the demoware timeout.


  * Augment the messaging pattern currently done using the `Message` and `Messagec` types in `lingo/service/server/service.go`:
    
  * Create `type Ingestc chan string` for transport of ingestion ping/signals w/o confusion with the Message type.
    
  * Modify the `CodeLingoService` interface so that the `Review` method signature includes returning an `Ingestc` as well.
    
  * Add `server.Ingestc` to the parameters passed to the I/O pipelines, in keeping with the addition of an `Ingestc` to the returned/exported values from the `CodeLingoService.Review` method.
    
  * Add code and logic to `app/commands/review/review.go` to take an `Ingestc` and use the signalling sent over to create a console progress bar using the `cheggaaa/pb` package.
    
  * Split off and read subscriber chans separately  in `Review` method on client in `service/service.go`  to make sure that what's printed to the console by the ingestion pings is complete before then sending the issues.
    
  * Directly print the messages from `messageSubc` in `service/service.go` directly inside the `client.Review` method.
    
  * Remove the `messagesc` printing from `app/commands/review/review.go`, given relocation (as per above)
    
  * For UX linearity, modify `Review(ops Options) function in `app/commands/review/review.go` so that is blocks until the ingest progress bar reaches 100%
