### PR TITLE
Make gogs repos created private by default.

### DIFF
--- a/vcs/git/git.go
+++ b/vcs/git/git.go
@@ -166,9 +166,8 @@ func (r *Repo) CreateRemote(name string) error {
 	}
 
 	_, err = gogsClient.CreateRepo(gogs.CreateRepoOption{
-		Name: name,
-		// TODO(waigani) make all repos private
-		Private:  false,
+		Name:     name,
+		Private:  true,
 		AutoInit: false,
 		//	Readme:   "Default",
 	})


### PR DESCRIPTION
  * Change `vcs/git` implementation of the `backing.Repo` interface method `CreateRemote(string) error` with the `gogs.CreateRepoOption` struct being initialised with the `Private` field set to "true" (was previously "false"), thus forcing any new gogs repositories to be initialised as **private** when first reviewed using Lingo.

(NOTE: This does not stop an administrator or the repo owner from using the gogs web portal to change the visibility manually.)

QA / Solution validation:
    1. Using existing Gogs setup (where all prior repositories are public).
    2. Run two browser apps separetely for A-B testing (where A is with codelingo-user = benjamin-rood as Gogs & codelingo_io admin, and B is with codelingo-user = sorrysorrysorry), signout of codelingo_io and gogs web apps and reset cookies/cache/history etc.
    3. Switch to `force-repos-private` branch of `codelingo/lingo`, and then `
go install`.
    4. Run `lingo setup`, with codelingo user A (benjamin-rood), using token generated by A browser signed in to the codelingo_io web app at localhost:3030.
    5. Create new test directory (repo), while setting the `git config ...` user details which match the user entered in `lingo setup`.
    6. Follow process of lingo readme specs, then run `lingo review`.
    7. As user A (admin), use admin panel on Gogs web app to see all repositories and confirm that the new repo is private.
    8. Make changes to the git repo inside our test directory (modifying files
 or adding additional ones) and then commit the changes, then run `lingo review`.
    9. Use admin panel on Gogs web app to confirm no changes have been made to the privacy/visibility of the repo.
    10. Repeat process of steps 5-10.
    11. Using the second browser (e.g. Firefox if browser A was Chrome), sign up at codelingo_io web app (on localhost 3030) as B user (sorrysorrysorry).
    12. Run `lingo setup` as codelingo user B (sorrysorrysorry), and generate the lingo token for user B on browser B also.
    13. Do steps 5-10.
    14. Confirmed for distinct codelingo users with differing permissions that all repos created, or modified/updated  by `lingo review` command are private.