### PR TITLE
Catch more verbose clql error.

### DIFF
--- a/app/util/util.go
+++ b/app/util/util.go
@@ -78,7 +78,7 @@ func userFacingErrMsg(mainErr error) string {
 		return fmt.Sprintf("error: Lingo doesn't support \"%s\" yet", lang)
 	// TODO this should be more specific parse error on platform:
 	//Error in S25: $(1,), Pos(offset=38, line=7, column=2), expected one of: < ! var indent id
-	case strings.Contains(message, "error: expected one of: < ! var indent id"):
+	case strings.Contains(message, "expected one of: < ! var indent id"):
 		return "error: Queries must not be terminated by colons."
 	case strings.Contains(message, "error: missing yield"):
 		return "error: You must yield a result, put '<' before any fact or property."


### PR DESCRIPTION
Catch and rewrite errors of the form
```
error: Error in S36: $(1,), Pos(offset=20, line=3, column=2), expected one of: < ! var indent id 
```
and return a useful message.