### PR TITLE
fix timeout error when no user input after review

### DIFF
--- a/app/commands/review/review.go
+++ b/app/commands/review/review.go
@@ -117,6 +117,7 @@ func Review(opts Options) ([]*codelingo.Issue, error) {
 	if opts.KeepAll {
 		timeout = time.After(time.Second * 30)
 	}
+
 l:
 	for {
 		select {

--- a/service/server/service.go
+++ b/service/server/service.go
@@ -55,7 +55,7 @@ func (ingc Ingestc) Send(s string) error {
 func (issc Issuec) Send(issue *codelingo.Issue) error {
 	select {
 	case issc <- issue:
-	case <-time.After(time.Second * 30):
+	case <-time.After(time.Hour * 1):
 		// TODO(waigani) error type
 		return errors.New("timeout")
 	}


### PR DESCRIPTION
Fix the issue by giving 1 hour time out instead of 30 seconds to write to the issue channel.