### PR TITLE
Mask masked Error

### DIFF
--- a/vcs/vcs.go
+++ b/vcs/vcs.go
@@ -87,7 +87,13 @@ func InitRepo(vcsType backing.VCSBacking) error {
 	// ensure creation of distinct remote.
 	repoName, err = CreateRepo(repo, repoName)
 	if err != nil {
-		return errors.Trace(err)
+
+		// TODO(waigani) TECHDEBT correct fix is to remove the go-gogs-client
+		// client and replace it with gogsclient in
+		// bots/clair/resource/gogsclient.go.
+		if err.Error() == "unexpected end of JSON input" {
+			return errors.New("VCS Error: 401 Unauthorised")
+		}
 	}
 	_, _, err = repo.SetRemote(repoOwner, repoName)
 	return err


### PR DESCRIPTION
The error message was a JSON unmarshal error, which was masking the underlying 401 error. Mask again with the error 401 message. If the client errors for another unknown reason, these errors will be lost. The correct fix is to remove the gogs client and make RESTful requests.