### PR TITLE
Fix gRPC connection bug.

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -164,7 +164,7 @@ func GrpcConnection(client, server string) (*grpc.ClientConn, error) {
 
 	var grpcAddr string
 	var isTLS bool
-	switch LocalClient {
+	switch client {
 	case LocalClient:
 		pCfg, err := config.Platform()
 		if err != nil {


### PR DESCRIPTION
The code to connect to the platform from the flow server was switching on a constant and always acted as through it was connecting from the client side. This worked on dev when the flow server had access to the flow server.