### PR TITLE
Log to stderr

### DIFF
--- a/app/commands/verify.go
+++ b/app/commands/verify.go
@@ -58,7 +58,10 @@ func (r require) Verify() error {
 		if err != nil {
 			if outdated {
 				// Don't error, just warn
-				fmt.Println("Warning: " + err.Error())
+				// TODO(waigani) use below and https://godoc.org/go.uber.org/zap/zapcore#NewConsoleEncoder
+				// util.Logger.Warn(err.Error())
+				fmt.Fprint(os.Stderr, err.Error(), "\n")
+
 				return nil
 			} else {
 				return errors.Trace(err)
@@ -183,7 +186,9 @@ func verifyLingoHome() error {
 	if _, err := os.Stat(scriptsHome); os.IsNotExist(err) {
 		err := os.MkdirAll(scriptsHome, 0775)
 		if err != nil {
-			fmt.Printf("WARNING: could not create scripts directory: %v \n", err)
+			// TODO(waigani) use below and https://godoc.org/go.uber.org/zap/zapcore#NewConsoleEncoder
+			// util.Logger.Warn("could not create scripts directory:", err.Error())
+			fmt.Fprint(os.Stderr, "could not create scripts directory:", err.Error())
 		}
 	}
 


### PR DESCRIPTION
Warning message was being printed to stdout via fmt.Print. This meant when a result set was being written to file, the warning was also written to file.

Write to stderr instead. See comments to refactor with console encoder later.