### PR TITLE
Add username to context

### DIFF
--- a/service/grpc/config.go
+++ b/service/grpc/config.go
@@ -8,9 +8,10 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 	"path/filepath"
+	"strings"
 )
 
-func GetGcloudEndpointCtx() (context.Context, error) {
+func AddGcloudApiKeyToCtx(ctx context.Context) (context.Context, error) {
 	configsHome, err := util.ConfigHome()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -24,8 +25,6 @@ func GetGcloudEndpointCtx() (context.Context, error) {
 		return nil, errors.Trace(err)
 	}
 
-	ctx := context.Background()
-
 	if env == "all" || env == "staging" {
 		cfg, err := commonConfig.Platform()
 		if err != nil {
@@ -36,9 +35,57 @@ func GetGcloudEndpointCtx() (context.Context, error) {
 			return nil, errors.Trace(err)
 		}
 
-		ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("x-api-key", gcloudAPIKey))
-		return ctx, nil
+		md, ok := metadata.FromOutgoingContext(ctx)
+		if !ok {
+			md = metadata.New(make(map[string]string))
+		}
+		md = md.Copy()
+		md["x-api-key"] = append(md["x-api-key"], gcloudAPIKey)
+
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 
 	return ctx, nil
+}
+
+func AddUsernameToCtx(ctx context.Context) (context.Context, error) {
+	authCfg, err := commonConfig.Auth()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// TODO: have a single CodeLingo username instead of using repo usernames
+	for i := 0; i < 3; i++ {
+		var username string
+		var err error
+
+		switch i {
+		case 0:
+			username, err = authCfg.GetGitUserName()
+		case 1:
+			username, err = authCfg.GetP4UserName()
+		default:
+			util.Logger.Warn("Using `demo` account - please run `lingo setup` to access your private repos.")
+			username, err = "demo", nil
+		}
+
+		if err != nil {
+			if strings.Contains(err.Error(), "Could not find value") {
+				continue
+			} else {
+				return nil, errors.Trace(err)
+			}
+		}
+
+		md, ok := metadata.FromOutgoingContext(ctx)
+		if !ok {
+			md = metadata.New(make(map[string]string))
+		}
+		md = md.Copy()
+		md["username"] = append(md["username"], username)
+
+		return metadata.NewOutgoingContext(ctx, md), nil
+	}
+
+	return nil, errors.New("failed to add username to context")
 }

--- a/service/service.go
+++ b/service/service.go
@@ -628,7 +628,7 @@ func New() (server.CodeLingoService, error) {
 	describeFactFactory := grpcclient.MakeDescribeFactEndpointFactory(tracer, tracingLogger, tlsOpt)
 	latestClientVersionFactory := grpcclient.MakeLatestClientVersionFactory(tracer, tracingLogger, tlsOpt)
 
-	newCtx, err := grpcclient.GetGcloudEndpointCtx()
+	newCtx, err := grpcclient.AddGcloudApiKeyToCtx(context.Background())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
Passes the client's username (or `demo` if not found) to the platform for repo access control.