### PR TITLE
adjust keep alive ping interval

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -205,8 +205,9 @@ func GrpcConnection(client, server string) (*grpc.ClientConn, error) {
 		tlsOpt = grpc.WithTransportCredentials(creds)
 	}
 
+	// todo (junyu) Ideally this ping time interval should be 50s
 	kpOpt := grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		Time: 50 * time.Second,
+		Time: 28 * time.Second,
 	})
 	// There may be multiple instances
 	cc, err := grpc.Dial(grpcAddr, tlsOpt, kpOpt)


### PR DESCRIPTION
Any ping time interval above 28 is not sufficient to keep the load balancer connection up consistently. 