### PR TITLE
Set some commands as dev only

### DIFF
--- a/app/commands/bots.go
+++ b/app/commands/bots.go
@@ -28,7 +28,7 @@ func init() {
 				Usage: "Describe the named Bot",
 			},
 		},
-	}, false)
+	}, false, true)
 }
 
 func listBotsAction(ctx *cli.Context) {

--- a/app/commands/config.go
+++ b/app/commands/config.go
@@ -73,7 +73,7 @@ func init() {
 				Usage: "Set the IP of the OnPrem Platform.",
 			},
 		},
-	}, false, homeRq, configRq)
+	}, false, false, homeRq, configRq)
 }
 
 func configAction(ctx *cli.Context) {

--- a/app/commands/describe_fact.go
+++ b/app/commands/describe_fact.go
@@ -32,7 +32,7 @@ func init() {
 				Usage: "The version of the lexicon containing the fact. Leave empty for the latest version.",
 			},
 		},
-	}, false, versionRq)
+	}, false, false, versionRq)
 }
 
 func describeFactAction(ctx *cli.Context) {

--- a/app/commands/flows.go
+++ b/app/commands/flows.go
@@ -28,7 +28,7 @@ func init() {
 				Usage: "Describe the named Flow",
 			},
 		},
-	}, false)
+	}, false, true)
 }
 
 func listFlowsAction(ctx *cli.Context) {

--- a/app/commands/hub.go
+++ b/app/commands/hub.go
@@ -4,8 +4,8 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/codelingo/lingo/app/util"
 	"github.com/juju/errors"
-	"runtime"
 	"os/exec"
+	"runtime"
 )
 
 func init() {
@@ -13,7 +13,7 @@ func init() {
 		Name:   "hub",
 		Usage:  "Opens the CodeLingo Hub in your default browser.",
 		Action: hubAction,
-	}, false)
+	}, false, true)
 }
 
 func hubAction(ctx *cli.Context) {

--- a/app/commands/lexicons.go
+++ b/app/commands/lexicons.go
@@ -59,7 +59,7 @@ func init() {
 				},
 			},
 		},
-	}, false, versionRq)
+	}, false, true, versionRq)
 }
 
 func listLexiconsAction(ctx *cli.Context) {

--- a/app/commands/list.go
+++ b/app/commands/list.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"github.com/codegangsta/cli"
 	"github.com/codelingo/lingo/app/util"
-	"github.com/juju/errors"
 	"github.com/codelingo/lingo/vcs"
+	"github.com/juju/errors"
 	"os"
 	"path/filepath"
 )
@@ -27,8 +27,7 @@ func init() {
 				Action: listLocalTenetsAction,
 			},
 		},
-
-	}, false, vcsRq)
+	}, false, false, vcsRq)
 }
 
 func listAllAction(ctx *cli.Context) {
@@ -64,7 +63,7 @@ func listLocalFlows(c *cli.Context) (string, error) {
 	str := `Flows:
   - review
   - search`
-  return str, nil
+	return str, nil
 }
 
 func listLocalTenetsAction(ctx *cli.Context) {

--- a/app/commands/new.go
+++ b/app/commands/new.go
@@ -19,7 +19,7 @@ func init() {
 		Name:   "init",
 		Usage:  "Create a .lingo file in the current directory.",
 		Action: newLingoAction,
-	}, false, vcsRq, versionRq)
+	}, false, false, vcsRq, versionRq)
 }
 
 // TODO(waigani) set lingo-home flag and test init creates correct home dir.

--- a/app/commands/pullrequest.go
+++ b/app/commands/pullrequest.go
@@ -41,7 +41,7 @@ var pullRequestCmd = &cli.Command{
 
 func init() {
 	register(pullRequestCmd,
-		true,
+		true, false,
 		homeRq, authRq, configRq, versionRq,
 	)
 }

--- a/app/commands/query_from_offset.go
+++ b/app/commands/query_from_offset.go
@@ -29,7 +29,7 @@ func init() {
 		Name:   "query-from-offset",
 		Usage:  "Generate CLQL query to match code in a specific section of a file.",
 		Action: pathFromOffsetAction,
-	}, false, versionRq)
+	}, false, false, versionRq)
 }
 
 func pathFromOffsetAction(ctx *cli.Context) {

--- a/app/commands/run.go
+++ b/app/commands/run.go
@@ -15,7 +15,7 @@ func init() {
 			reviewCommand,
 			searchCommand,
 		},
-	}, false)
+	}, false, false)
 }
 
 func runAction(ctx *cli.Context) {

--- a/app/commands/tenets.go
+++ b/app/commands/tenets.go
@@ -32,7 +32,7 @@ func init() {
 				Usage: "List all Tenets of the given bundle",
 			},
 		},
-	}, false)
+	}, false, true)
 }
 
 func listTenetsAction(ctx *cli.Context) {

--- a/app/commands/update.go
+++ b/app/commands/update.go
@@ -20,7 +20,7 @@ func init() {
 		Usage:  "Update the lingo client to the latest release.",
 		Action: updateAction,
 	},
-		false,
+		false, false,
 		homeRq,
 		authRq,
 		configRq,


### PR DESCRIPTION
To view help for and run dev only commands, the `LINGO_DEV_CLI` environment variable must be `true`. Otherwise, they won't appear in the help message and won't be able to be run.