### PR TITLE
enable list-fact command in CLI

### DIFF
--- a/app/commands/lexicons.go
+++ b/app/commands/lexicons.go
@@ -192,7 +192,7 @@ func listFacts(ctx *cli.Context) error {
 		owner = args[0]
 		name = args[1]
 	} else {
-		return errors.New("Please specify a properly namespaced lexicon, ie,\nlingo lexicons list-facts codelingo/go")
+		return errors.New("please specify a properly namespaced lexicon, ie,\nlingo lexicons list-facts codelingo/go")
 	}
 
 	facts, err := svc.ListFacts(owner, name, ctx.String("version"))

--- a/app/commands/lexicons.go
+++ b/app/commands/lexicons.go
@@ -191,7 +191,7 @@ func listFacts(ctx *cli.Context) error {
 		owner = args[0]
 		name = args[1]
 	} else {
-		return errors.New("Please specify a properly namespaced lexicon, ie,\nlingo lexicon list-facts codelingo/go")
+		return errors.New("Please specify a properly namespaced lexicon, ie,\nlingo lexicons list-facts codelingo/go")
 	}
 
 	facts, err := svc.ListFacts(owner, name, ctx.String("version"))

--- a/app/commands/lexicons.go
+++ b/app/commands/lexicons.go
@@ -17,6 +17,7 @@ import (
 
 func init() {
 	register(&cli.Command{
+		Hidden: true,
 		Name:   "lexicons",
 		Usage:  "List Lexicons",
 		Action: listLexiconsAction,

--- a/app/commands/lexicons.go
+++ b/app/commands/lexicons.go
@@ -59,7 +59,7 @@ func init() {
 				},
 			},
 		},
-	}, false, true, versionRq)
+	}, false, false, versionRq)
 }
 
 func listLexiconsAction(ctx *cli.Context) {


### PR DESCRIPTION
This is to enable list-fact command in CLI so the list fact call from sublime plugin does not get an error.
It also fixes the error message when no argument is passed in. 