### PR TITLE
Default Interactive Review

### DIFF
--- a/app/util/flags.go
+++ b/app/util/flags.go
@@ -80,9 +80,9 @@ var (
 		"version",
 		"v",
 	}
-	InteractiveFlg = flagName{
-		"interactive",
-		"i",
+	KeepAllFlg = flagName{
+		"keep-all",
+		"k",
 	}
 	DirectoryFlg = flagName{
 		"directory",


### PR DESCRIPTION
- Remove "-i" flag
- `lingo run review` prompts for user input
- Default output is json struct to stdout
- "--output -o" flag writes to file
- "--format -f" formats the output, current valid formats are: "json", "json-pretty"