### PR TITLE
Tidy Up Repo Sync

### DIFF
--- a/app/commands/review.go
+++ b/app/commands/review.go
@@ -125,13 +125,6 @@ func reviewCMD(cliCtx *cli.Context) (string, error) {
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	if err := vcs.InitRepo(vcsType, repo); err != nil {
-		// TODO(waigani) use error types
-		// Note: Prior repo init is a valid state.
-		if !strings.Contains(err.Error(), "already exists") {
-			return "", errors.Trace(err)
-		}
-	}
 
 	// TODO: replace this system with nfs-like communication.
 	fmt.Println("Syncing your repo...")

--- a/vcs/git/git.go
+++ b/vcs/git/git.go
@@ -39,8 +39,15 @@ func (r *Repo) SetRemote(repoOwner, repoName string) (string, string, error) {
 	if err != nil {
 		return "", "", errors.Trace(err)
 	}
+
+	// Attempt to remove existing remote.
+	out, err := gitCMD("remote", "remove", remoteName)
+	if err != nil && !strings.Contains(err.Error(), "No such remote") {
+		return "", "", errors.Annotate(err, out)
+	}
+
 	remoteAddr := fmt.Sprintf("%s/%s/%s.git", addr, repoOwner, repoName)
-	out, err := gitCMD("remote", "add", remoteName, remoteAddr)
+	out, err = gitCMD("remote", "add", remoteName, remoteAddr)
 	if err != nil {
 		return "", "", errors.Annotate(err, out)
 	}


### PR DESCRIPTION
Fix a bug where the local and remote were out of sync, causing a new remote repository to be created on every review without updating. Remove the redundant InitRepo method and "lazy load" the repository on each sync attempt:

- Attempt to sync the local repo with the remote on each review
- On failure, create a new remote, add the new remote address to git and attempt to sync again

This PR also improves an error message to prompt user to add first commit if missing.