### PR TITLE
Filter query gen properties

### DIFF
--- a/app/commands/query_from_offset.go
+++ b/app/commands/query_from_offset.go
@@ -82,11 +82,31 @@ func pathFromOffset(ctx *cli.Context) error {
 		return errors.Annotate(badArgsErr, err.Error())
 	}
 
+	filterPaths(paths, ctx)
+
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(paths.Paths)
 	content := buf.Bytes()
 	outputBytes("", content)
 	return nil
+}
+
+func filterPaths(paths *server.PathsFromOffsetResponse, ctx *cli.Context) {
+	if ctx.Bool("all-properties") {
+		return
+	}
+
+	for _, path := range paths.Paths {
+		for i, fact := range path.Facts {
+			if ctx.Bool("final-fact-properties") {
+				if i+1 != len(path.Facts) {
+					fact.Properties = make(map[string]string)
+				}
+			} else {
+				fact.Properties = make(map[string]string)
+			}
+		}
+	}
 }
 
 func validateFilePath(path string) (string, error) {

--- a/app/commands/tooling.go
+++ b/app/commands/tooling.go
@@ -3,11 +3,12 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
+
 	"github.com/codegangsta/cli"
 	"github.com/codelingo/lingo/app/util"
 	"github.com/codelingo/lingo/service"
 	"github.com/juju/errors"
-	"strings"
 )
 
 func init() {
@@ -39,6 +40,16 @@ func init() {
 				Name:   "query-from-offset",
 				Usage:  "Generate CLQL query to match code in a specific section of a file.",
 				Action: pathFromOffsetAction,
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "all-properties, a",
+						Usage: "List all properties of all facts in the query path",
+					},
+					cli.BoolFlag{
+						Name:  "final-fact-properties, f",
+						Usage: "List all properties of the final fact in the query path",
+					},
+				},
 			},
 		},
 	}, false, false, versionRq)


### PR DESCRIPTION
Add flags to query-by-offset to filter out properties of facts in the query.
By default, no properties are shown. The "all-properties, a" flag includes
properties on all facts. The "final-fact-properties, f" flag includes
properties on only the final fact of the path.