### PR TITLE
Use rendered Codemod Set CLQL

### DIFF
--- a/app/commands/codemod/review.go
+++ b/app/commands/codemod/review.go
@@ -189,7 +189,7 @@ l:
 				return nil, errors.Trace(err)
 			}
 
-			clqlStr := "import codelingo/ast/go\n" + dLingo.Tenets[0].Bots["codelingo/codemod"]["set"].(string)
+			clqlStr := "import codelingo/ast/go\n" + iss.Comment
 
 			// support one set decorator per query.
 			srcs, err := ClqlToSrc(string(clqlStr))


### PR DESCRIPTION
Use the "comment" of the issue returned as the CLQL to modify code. This
ensures any template variables are rendered into the query.