### PR TITLE
IPv4

### DIFF
--- a/app/commands/verify.go
+++ b/app/commands/verify.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"context"
+
 	"github.com/blang/semver"
 	"github.com/codelingo/lingo/app/util"
 	"github.com/codelingo/lingo/app/util/common"
@@ -311,7 +312,7 @@ func verifyClientVersion() error {
 	}
 
 	if compare < 0 {
-		return errors.New("Your client is out of date. This may result in unexpected behaviour.")
+		return errors.New("Your client is out of date. Run `lingo update` to automatically update it.")
 	} else if compare > 0 {
 		return errors.New("Your client is newer than the platform. This may result in unexpected behaviour.")
 	} else {

--- a/vcs/git/git.go
+++ b/vcs/git/git.go
@@ -223,7 +223,7 @@ func (r *Repo) Sync(repoOwner string, workingDir string) error {
 		return errors.Trace(err)
 	}
 	// sync local and remote before reviewing
-	_, err = gitCMD("push", remote, "HEAD", "--force", "--no-verify")
+	_, err = gitCMD("push", "-4", remote, "HEAD", "--force", "--no-verify")
 	return errors.Trace(err)
 }
 
@@ -312,7 +312,7 @@ func (r *Repo) CheckoutRemote(sha string) error {
 	}
 
 	// fetch origin
-	if _, err = gitCMD("fetch", "origin"); err != nil {
+	if _, err = gitCMD("fetch", "-4", "origin"); err != nil {
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION
Add the "-4" flag to git commands to skip lookups for IPv6 when talking to the Codelingo platform. Update the "lingo out of date" error to be more helpful.