### PR TITLE
Update GRPC go dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -466,7 +466,7 @@
     "unix",
     "windows"
   ]
-  revision = "8b4580aae2a0dd0c231a45d3ccb8434ff533b840"
+  revision = "d0be0721c37eeb5299f245a996a483160fc36940"
 
 [[projects]]
   branch = "master"
@@ -516,15 +516,18 @@
     "balancer",
     "balancer/base",
     "balancer/roundrobin",
-    "channelz",
     "codes",
     "connectivity",
     "credentials",
     "encoding",
     "encoding/proto",
-    "grpclb/grpc_lb_v1/messages",
     "grpclog",
     "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/transport",
     "keepalive",
     "metadata",
     "naming",
@@ -534,11 +537,10 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap",
-    "transport"
+    "tap"
   ]
-  revision = "7a6a684ca69eb4cae85ad0a484f2e531598c047b"
-  version = "v1.12.2"
+  revision = "8dea3dc473e90c8179e519d91302d0597c0ca1d1"
+  version = "v1.15.0"
 
 [[projects]]
   branch = "v1"
@@ -579,6 +581,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b6862e39221cfef2801d5fc5403584ae202b174c7586fdaccc4357b8465cd043"
+  inputs-digest = "a7ae822367e3de2fcd21fd5b8fb7da1987bf67c53bd1fbc74ebfe58348c83bc5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,7 +67,7 @@ ignored = ["github.com/codelingo/lingo/_examples"]
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "1.12.1"
+  version = "1.15.0"
 
 [[constraint]]
   name = "gopkg.in/check.v1"


### PR DESCRIPTION
Not strictly necessary but updating to keep inline with platform version.