### PR TITLE
Remove platform version checks

### DIFF
--- a/app/util/common/common.go
+++ b/app/util/common/common.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 )
 
-const ClientVersion = "0.6.0"
+const ClientVersion = "0.6.1"
 
 var LingoFilenames = map[string]bool{
 	"codelingo.yaml": true,


### PR DESCRIPTION
Clusters will always be running the latest platform version, so no need to check. Instead check for CLI updates once every few hours.