### PR TITLE
Rm cert

### DIFF
--- a/app/commands/query_from_offset.go
+++ b/app/commands/query_from_offset.go
@@ -27,6 +27,7 @@ USAGE:
 func queryFromOffsetAction(ctx *cli.Context) {
 	err := queryFromOffset(ctx)
 	if err != nil {
+		util.Logger.Debug(errors.ErrorStack(err))
 		util.FatalOSErr(err)
 		return
 	}

--- a/app/commands/tooling.go
+++ b/app/commands/tooling.go
@@ -25,6 +25,10 @@ func init() {
 				Usage:  "List available facts for a given lexicon.",
 				Action: listFactsAction,
 				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "debug",
+						Usage: "Display debug messages",
+					},
 					cli.StringFlag{
 						Name:  util.FormatFlg.String(),
 						Usage: "The format for the output. Can be listed (default) or \"json\" encoded.",
@@ -45,6 +49,10 @@ func init() {
 				Action: queryFromOffsetAction,
 				Flags: []cli.Flag{
 					cli.BoolFlag{
+						Name:  "debug",
+						Usage: "Display debug messages",
+					},
+					cli.BoolFlag{
 						Name:  "all-properties, a",
 						Usage: "List all properties of all facts in the query path",
 					},
@@ -61,6 +69,7 @@ func init() {
 func listFactsAction(ctx *cli.Context) {
 	err := listFacts(ctx)
 	if err != nil {
+		util.Logger.Debug(errors.ErrorStack(err))
 		util.FatalOSErr(err)
 		return
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -8,8 +8,10 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"os/user"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/codelingo/lingo/app/util"
 	"github.com/codelingo/lingo/app/util/common/config"
@@ -227,18 +229,13 @@ func ListLexicons(ctx context.Context) ([]string, error) {
 }
 
 func ListFacts(ctx context.Context, owner, name, version string) (map[string][]string, error) {
-	conn, err := GrpcConnection(LocalClient, PlatformServer, false)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	c := rpc.NewCodeLingoClient(conn)
-
 	req := &rpc.ListFactsRequest{
 		Owner:   owner,
 		Name:    name,
 		Version: version,
 	}
-	reply, err := c.ListFacts(ctx, req)
+
+	reply, err := listFacts(ctx, req, 1)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -249,8 +246,43 @@ func ListFacts(ctx context.Context, owner, name, version string) (map[string][]s
 		factMap[parent] = children.Child
 	}
 
-	return factMap, nil
+	return factMap, errors.Trace(err)
+}
 
+func listFacts(ctx context.Context, req *rpc.ListFactsRequest, attempt int) (*rpc.FactList, error) {
+	conn, err := GrpcConnection(LocalClient, PlatformServer, false)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	c := rpc.NewCodeLingoClient(conn)
+
+	reply, err := c.ListFacts(ctx, req)
+	if err != nil {
+		if strings.Contains(err.Error(), certErrorString) {
+			path, err := platformCertPath()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			err = os.Remove(path)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			// retry 5 times
+			// TODO: exponential backoff and annotate with connection error
+			if attempt >= maxAttempts {
+				return nil, errors.Errorf("attempted to connect %d times", attempt)
+			}
+
+			reply, err = listFacts(ctx, req, attempt+1)
+			return reply, errors.Trace(err)
+		} else {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	return reply, nil
 }
 
 func DescribeFact(ctx context.Context, owner, name, version, fact string) (*rpc.DescribeFactReply, error) {
@@ -274,7 +306,23 @@ func DescribeFact(ctx context.Context, owner, name, version, fact string) (*rpc.
 	return reply, nil
 }
 
+const certErrorString string = "transport: authentication handshake failed: x509: certificate signed by unknown authority"
+
+func platformCertPath() (string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return path.Join(usr.HomeDir, ".codelingo/certs/paas/grpc-platform.codelingo.io:443.cert"), nil
+}
+
+const maxAttempts int = 5
+
 func QueryFromOffset(ctx context.Context, req *rpc.QueryFromOffsetRequest) (*rpc.QueryFromOffsetReply, error) {
+	reply, err := queryFromOffset(ctx, req, 1)
+	return reply, errors.Trace(err)
+}
+func queryFromOffset(ctx context.Context, req *rpc.QueryFromOffsetRequest, attempt int) (*rpc.QueryFromOffsetReply, error) {
 	conn, err := GrpcConnection(LocalClient, PlatformServer, false)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -283,7 +331,28 @@ func QueryFromOffset(ctx context.Context, req *rpc.QueryFromOffsetRequest) (*rpc
 
 	reply, err := c.QueryFromOffset(ctx, req)
 	if err != nil {
-		return nil, errors.Trace(err)
+		if strings.Contains(err.Error(), certErrorString) {
+			path, err := platformCertPath()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			err = os.Remove(path)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			// retry 5 times
+			// TODO: exponential backoff and annotate with connection error
+			if attempt >= maxAttempts {
+				return nil, errors.Errorf("attempted to connect %d times", attempt)
+			}
+
+			reply, err = queryFromOffset(ctx, req, attempt+1)
+			return reply, errors.Trace(err)
+		} else {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	return reply, nil

--- a/service/service.go
+++ b/service/service.go
@@ -221,7 +221,7 @@ func ListLexicons(ctx context.Context) ([]string, error) {
 	req := &rpc.ListLexiconsRequest{}
 	reply, err := c.ListLexicons(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	return reply.Lexicons, nil
 }
@@ -240,7 +240,7 @@ func ListFacts(ctx context.Context, owner, name, version string) (map[string][]s
 	}
 	reply, err := c.ListFacts(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	factMap := make(map[string][]string)
@@ -268,7 +268,7 @@ func DescribeFact(ctx context.Context, owner, name, version, fact string) (*rpc.
 	}
 	reply, err := c.DescribeFact(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	return reply, nil
@@ -283,7 +283,7 @@ func QueryFromOffset(ctx context.Context, req *rpc.QueryFromOffsetRequest) (*rpc
 
 	reply, err := c.QueryFromOffset(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	return reply, nil
@@ -299,7 +299,7 @@ func LatestClientVersion(ctx context.Context) (string, error) {
 	req := &rpc.LatestClientVersionRequest{}
 	reply, err := c.LatestClientVersion(ctx, req)
 	if err != nil {
-		return "", err
+		return "", errors.Trace(err)
 	}
 
 	return reply.Version, nil


### PR DESCRIPTION
Remove the platform certificate if we get a `transport: authentication handshake failed: x509: certificate signed by unknown authority` error.